### PR TITLE
Improve build so that we can build an sdist

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -40,10 +40,10 @@ jobs:
         run: uv run --locked --all-extras --dev pytest
 
       - name: Build wheel
-        run: uv build --wheel 
+        run: uv build 
 
       - name: Auditwheel repair wheel
         run: uv run --dev auditwheel repair dist/*.whl
 
       - name: Publish repaired wheel to PyPi
-        run: uv publish wheelhouse/*
+        run: uv publish wheelhouse/* dist/*.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ venv:
 
 
 dist:
-	uv build --wheel
+	uv build
 
 download-docs:
 	mkdir -p dist/vm-docs
@@ -37,5 +37,6 @@ clean:
 	rm --one-file-system -r .venv
 	rm --one-file-system -r dist
 	rm --one-file-system -r pkg
+	rm --one-file-system -r wheelhouse
 
 .PHONY: venv dist download-docs generate_funcs test clean format-lib check_generated_funcs

--- a/README.md
+++ b/README.md
@@ -16,6 +16,10 @@ Highlights include:
 
 HeraclesQL is available on PyPi. Just `pip install heracles-ql`
 
+HeraclesQL depends on native code in a few places. Right now, we provide binaries for `manylinux_2_34_x86_64`.
+
+Otherwise, we provide an sdist that includes the native source code. In order to build the sdist, you'll need a
+modern Go compiler.
 
 ## Example
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -7,4 +7,15 @@ class BuildSharedObjectd(BuildHookInterface):
     def initialize(self, version, build_data):
         build_data["pure_python"] = False
 
-        subprocess.check_output(["make", "format-lib"])
+        subprocess.check_output(
+            [
+                "go",
+                "build",
+                "-C",
+                "formatter",
+                "-buildmode=c-shared",
+                "-o",
+                "../pkg/formatter.so",
+                "formatter.go",
+            ]
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "heracles-ql"
-version = "0.1.0"
+version = "0.1.1"
 description = "heralces-ql VictoriaMetrics DSL"
 readme = "README.md"
 authors = [{name = "Hudson River Trading LLC", email="opensource@hudson-trading.com"}]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,6 @@ build-backend = "hatchling.build"
 [tool.hatch.build.targets.wheel]
 packages = ["heracles"]
 
-[tool.uv]
-# this is needed so that UV always builds the formatlib, even when
-# it thinks it has a cached copy of the heracles python package
-reinstall-package = ["heracles-ql"]
 
 [project.optional-dependencies]
 config = [
@@ -37,12 +33,28 @@ dev = [
     "wheel>=0.45.1",
 ]
 
+[tool.uv]
+# setting these cache keys ensures uv will rebuild the project when any Go source
+# files change. It DOES NOT protect against deleteing the pkg directory, so in those
+# cases the user still must be uv sync --reinstall-package heracles-ql
+cache-keys = [
+  { file = "pyproject.toml" },
+  { file = "formatter/**" },
+  { git = { commit = true } },
+]
 
 # this line includes hatch_build.py as a build plugin
 [tool.hatch.build.targets.wheel.hooks.custom]
 
 [tool.hatch.build.targets.wheel.force-include]
 "pkg/formatter.so" = "pkg/formatter.so"
+
+[tool.hatch.build.targets.sdist]
+include = [
+  "formatter/**",
+  "heracles/**"
+]
+
 
 [tool.ruff]
 select = [


### PR DESCRIPTION
Updates the build so that the sdist includes the correct files and adjust `hatch_build.py` so that the Makefile isn't required for building the package. Also improves the caching behavior so that uv doesn't need to rebuild to Go project so frequently.

Bump the package version to 0.1.1.