### PR TITLE
fix publish-to-pypi action

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -37,7 +37,7 @@ jobs:
         run: make format-lib
 
       - name: Run tests
-        run: uv run --locked --all-extras --dev pytest
+        run: uv run --all-extras --dev pytest
 
       - name: Build wheel
         run: uv build 


### PR DESCRIPTION
#7 removed the lockfile. This causes `uv run --locked` to break. We shouldn't be passing `--locked`, so this change just removes it.