### PR TITLE
Preserve rule template metadata across realizations

### DIFF
--- a/heracles/config/rule.py
+++ b/heracles/config/rule.py
@@ -206,11 +206,11 @@ class SimpleAlert(Alert):
             raise ValueError("expression must be present to realize alert")
 
         labels = self.labels.copy()
-        if override_labels := typed_args.get("labels", dict[str, str]):
+        if override_labels := typed_args.get("labels", dict):
             labels.update(override_labels)
 
         annotations = self.annotations.copy()
-        if override_annotations := typed_args.get("annotations", dict[str, str]):
+        if override_annotations := typed_args.get("annotations", dict):
             annotations.update(override_annotations)
 
         override_name = typed_args.get("name", str)
@@ -299,7 +299,7 @@ class SimpleRecording(Recording):
             raise ValueError("expression must be present to realize recording rule")
 
         labels = self.labels.copy()
-        if override_labels := typed_args.get("labels", dict[str, str]):
+        if override_labels := typed_args.get("labels", dict):
             labels.update(override_labels)
 
         return RealizedRecording(

--- a/heracles/config/rule.py
+++ b/heracles/config/rule.py
@@ -205,11 +205,11 @@ class SimpleAlert(Alert):
         if not self.expr and not typed_args.get("expr", Expr[RealizedAlert]):  # type: ignore
             raise ValueError("expression must be present to realize alert")
 
-        labels = self.labels or {}
+        labels = self.labels.copy()
         if override_labels := typed_args.get("labels", dict[str, str]):
             labels.update(override_labels)
 
-        annotations = self.annotations or {}
+        annotations = self.annotations.copy()
         if override_annotations := typed_args.get("annotations", dict[str, str]):
             annotations.update(override_annotations)
 
@@ -298,7 +298,7 @@ class SimpleRecording(Recording):
         if not self.expr and not typed_args.get("expr", Expr[RealizedRecording]):  # type: ignore
             raise ValueError("expression must be present to realize recording rule")
 
-        labels = self.labels or {}
+        labels = self.labels.copy()
         if override_labels := typed_args.get("labels", dict[str, str]):
             labels.update(override_labels)
 

--- a/test/config/rule_test.py
+++ b/test/config/rule_test.py
@@ -103,6 +103,46 @@ def test_rename_recording_rule() -> None:
     assert config.RuleBundle._rename_recording_rule("a_b_c") == "a:b:c"
 
 
+def test_alert_realization_does_not_mutate_template_metadata() -> None:
+    template = config.SimpleAlert(
+        name="TestingRule",
+        expr=ql.Selector().example_metric,
+        labels={"base": "label"},
+        annotations={"base": "annotation"},
+    )
+
+    first = template.realize(
+        labels={"variant": "first"},
+        annotations={"variant": "first"},
+    )
+    second = template.realize(
+        labels={"variant": "second"},
+        annotations={"variant": "second"},
+    )
+
+    assert first.labels == {"base": "label", "variant": "first"}
+    assert first.annotations == {"base": "annotation", "variant": "first"}
+    assert second.labels == {"base": "label", "variant": "second"}
+    assert second.annotations == {"base": "annotation", "variant": "second"}
+    assert template.labels == {"base": "label"}
+    assert template.annotations == {"base": "annotation"}
+
+
+def test_recording_realization_does_not_mutate_template_labels() -> None:
+    template = config.SimpleRecording(
+        name="testing:rule",
+        expr=ql.Selector().example_metric,
+        labels={"base": "label"},
+    )
+
+    first = template.realize(labels={"variant": "first"})
+    second = template.realize(labels={"variant": "second"})
+
+    assert first.labels == {"base": "label", "variant": "first"}
+    assert second.labels == {"base": "label", "variant": "second"}
+    assert template.labels == {"base": "label"}
+
+
 def test_assertion_extraction() -> None:
     rules = config.RuleBundle(name="test_bundle")
 


### PR DESCRIPTION
## Summary
- copy alert labels and annotations before applying per-realization overrides
- copy recording labels before merging overrides for the same reason
- add regressions showing that sequential variants stay independent and reusable templates remain unchanged

Without the copies, any non-empty template metadata dictionary was updated in place. A later realization could inherit labels or annotations supplied only for an earlier variant.

## Validation
- `git diff --check`
- `uv format --diff`

## Remote Linux validation
- `git diff --check`
- `uv format --diff`
- `uv run --all-extras --dev mypy heracles`
- `uv run --all-extras --dev pytest`