### PR TITLE
Isolate annotations on selected vectors

### DIFF
--- a/heracles/ql/prelude.py
+++ b/heracles/ql/prelude.py
@@ -358,7 +358,7 @@ class SelectedInstantVector(InstantVector):
         res_vec = SelectedInstantVector(name=self.name, **self._selectors)
         # SelectedInstantVector is special - selecting causes this node to be
         # replaced with the selector, so the annotations should propogate
-        res_vec._annotations = self._annotations  # type: ignore
+        res_vec._annotations = self._annotations.copy()  # type: ignore
         for name, value in kwargs.items():
             res_vec._selectors[name] = value
         return res_vec

--- a/test/stdlib/acceptance_test.py
+++ b/test/stdlib/acceptance_test.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from heracles import ql
+from heracles.ql import assertions
 
 comparison_ops = {
     ql.BinopKind.eq,
@@ -223,3 +224,22 @@ def test_all_binops_implemented(
 )
 def test_expressions(expr: ql.Timeseries, result: str) -> None:
     assert ql.format(expr.render()) == result
+
+
+def test_selected_vector_annotations_are_isolated() -> None:
+    base = ql.SelectedInstantVector(name="up").annotate(assertions.assert_exists)
+    prod = base(job="prod")
+    stage = base(job="stage")
+
+    prod.annotate(assertions.assert_exactly_one("instance"))
+
+    assert [annotation.assertion().render() for annotation in base.annotations] == [
+        "absent(up{})"
+    ]
+    assert [annotation.assertion().render() for annotation in prod.annotations] == [
+        'absent(up{job="prod"})',
+        '(count(up{job="prod"}) by (instance) != 1.0)',
+    ]
+    assert [annotation.assertion().render() for annotation in stage.annotations] == [
+        'absent(up{job="stage"})'
+    ]


### PR DESCRIPTION
Fixes #12.

## What changed

`SelectedInstantVector.__call__` now copies the propagated annotation list instead of sharing it with the source vector. This keeps the existing behavior where annotations on a base vector carry into later label selections, but prevents annotations added to one selected expression from leaking into siblings.

## Why

Before this change, this sequence shared one `_annotations` list across `base`, `prod`, and `stage`:

```python
base = ql.SelectedInstantVector(name="up").annotate(assertions.assert_exists)
prod = base(job="prod")
stage = base(job="stage")
prod.annotate(assertions.assert_exactly_one("instance"))
```

That made `stage.annotations` include the `assert_exactly_one("instance")` assertion even though only `prod` was annotated after selection. In alert-generation contexts this can create extra assertion alerts for the wrong selected vector.

## Validation

Ran locally:

```text
git diff --check
.venv/bin/python -m pytest test/stdlib/acceptance_test.py::test_selected_vector_annotations_are_isolated
uv format --diff
uv run --all-extras --dev pytest
uv run --all-extras --dev mypy heracles
```
