### PR TITLE
Isolate BinaryOp label modifier variants

### DIFF
--- a/heracles/ql/prelude.py
+++ b/heracles/ql/prelude.py
@@ -464,23 +464,29 @@ class BinaryOp(InstantVector):
         self.ignoring_labels: list[str] = []
         self.group_by: tuple[str, Iterable[str]] | None = None
 
-    def on(self, *labels: str) -> Self:
+    def _copy_with_label_modifiers(self) -> Self:
         copied = copy.copy(self)
+        copied.on_labels = self.on_labels.copy()
+        copied.ignoring_labels = self.ignoring_labels.copy()
+        return copied
+
+    def on(self, *labels: str) -> Self:
+        copied = self._copy_with_label_modifiers()
         copied.on_labels.extend(labels)
         return copied
 
     def ignoring(self, *labels: str) -> Self:
-        copied = copy.copy(self)
+        copied = self._copy_with_label_modifiers()
         copied.ignoring_labels.extend(labels)
         return copied
 
     def group_left(self, *labels: str) -> Self:
-        copied = copy.copy(self)
+        copied = self._copy_with_label_modifiers()
         copied.group_by = ("group_left", labels)
         return copied
 
     def group_right(self, *labels: str) -> Self:
-        copied = copy.copy(self)
+        copied = self._copy_with_label_modifiers()
         copied.group_by = ("group_right", labels)
         return copied
 

--- a/test/stdlib/acceptance_test.py
+++ b/test/stdlib/acceptance_test.py
@@ -223,3 +223,31 @@ def test_all_binops_implemented(
 )
 def test_expressions(expr: ql.Timeseries, result: str) -> None:
     assert ql.format(expr.render()) == result
+
+
+def test_binary_op_label_modifiers_are_isolated() -> None:
+    base = ql.SelectedInstantVector(name="left") * ql.SelectedInstantVector(
+        name="right"
+    )
+    by_host = base.on("host")
+    by_instance = base.on("instance")
+
+    assert base.render() == "(left{} * right{})"
+    assert by_host.render() == "(left{} * on (host) right{})"
+    assert by_instance.render() == "(left{} * on (instance) right{})"
+
+    ignored_job = base.ignoring("job")
+    ignored_env = base.ignoring("env")
+
+    assert base.render() == "(left{} * right{})"
+    assert ignored_job.render() == "(left{} * ignoring (job) right{})"
+    assert ignored_env.render() == "(left{} * ignoring (env) right{})"
+
+    grouped_left = base.group_left("service")
+    grouped_right = base.group_right("cluster")
+    by_pod = base.on("pod")
+
+    assert base.render() == "(left{} * right{})"
+    assert grouped_left.render() == "(left{} * group_left(service) right{})"
+    assert grouped_right.render() == "(left{} * group_right(cluster) right{})"
+    assert by_pod.render() == "(left{} * on (pod) right{})"


### PR DESCRIPTION
Fixes #14.

## What changed

`BinaryOp` now detaches its mutable label modifier lists before returning variants from `on(...)`, `ignoring(...)`, `group_left(...)`, and `group_right(...)`.

## Why

Those methods used `copy.copy(self)` and then mutated lists that were still shared with the source expression. That made later modifier calls change earlier expressions:

```python
base = ql.SelectedInstantVector(name="left") * ql.SelectedInstantVector(name="right")
by_host = base.on("host")
by_instance = base.on("instance")
```

Before this change, all three expressions rendered with `on (host,instance)`. The base expression should stay unmodified, and each variant should keep only the labels it was given.

The same copy helper is used for `group_left`/`group_right` because those variants can otherwise inherit later `on`/`ignoring` mutations through the shared lists.

## Validation

Ran locally:

```text
git diff --check
.venv/bin/python -m pytest test/stdlib/acceptance_test.py::test_binary_op_label_modifiers_are_isolated
uv format --diff
uv run --all-extras --dev pytest
uv run --all-extras --dev mypy heracles
```
