### PR TITLE
Support scalar true division for durations

### DIFF
--- a/heracles/ql/prelude.py
+++ b/heracles/ql/prelude.py
@@ -728,8 +728,10 @@ class Duration(Renderable):
     def __rmul__(self, o: float | int) -> Duration:
         return Duration._scalar_binop(o, self, operator.mul)
 
-    def __truediv__(self, o: Duration) -> Duration:
-        return self._binop(o, operator.truediv)
+    def __truediv__(self, o: Duration | float | int) -> Duration:
+        if isinstance(o, Duration):
+            return self._binop(o, operator.truediv)
+        return Duration._scalar_binop(self, o, operator.truediv)
 
     def __rtruediv__(self, o: Duration) -> Duration:
         return Duration._scalar_binop(o, self, operator.truediv)
@@ -789,9 +791,9 @@ class Duration(Renderable):
             for unit in sorted_duration_units:
                 res, new_remainder = divmod(remainder, unit.unit_factor())
                 if res > 0 and unit != DurationUnit.millisecond:
-                    parts.append(f"{res}{unit.unit_name()}")
+                    parts.append(f"{_render_duration_value(res)}{unit.unit_name()}")
                 elif unit == DurationUnit.millisecond and remainder != 0:
-                    parts.append(f"{remainder}ms")
+                    parts.append(f"{_render_duration_value(remainder)}ms")
                 remainder = new_remainder
 
             time = "".join(parts)
@@ -807,6 +809,12 @@ class Duration(Renderable):
 
     def __repr__(self) -> str:
         return self.render()
+
+
+def _render_duration_value(value: float) -> str:
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value))
+    return str(value)
 
 
 InstantOrRangeVector = TypeVar("InstantOrRangeVector", InstantVector, RangeVector)

--- a/test/stdlib/acceptance_test.py
+++ b/test/stdlib/acceptance_test.py
@@ -214,6 +214,7 @@ def test_all_binops_implemented(
             r'example_vector{instance="\"fo\\.o"}',
         ),
         (5 * ql.Minute, "5m"),
+        (5 * ql.Minute / 2, "2m30s"),
         (0 * ql.Second, "0ms"),
         (
             ql.label_match(ql.SelectedInstantVector(name="test"), "foo", r"foo\|bar"),


### PR DESCRIPTION
Fixes #16.

`Duration` already supports scalar multiplication and floor division, but true division currently routes through the Duration/Duration `_binop()` path. As a result, expressions like `5 * ql.Minute / 2` raise `AttributeError` because the scalar divisor has no `time_value`.

This keeps the existing Duration/Duration behavior, sends numeric divisors through `_scalar_binop()`, and normalizes whole-number float components while rendering so scalar division emits the same compact duration syntax as the existing integer paths.

Validation:
- `git diff --check`
- `.venv/bin/python -m pytest test/stdlib/acceptance_test.py::test_expressions`
- `uv format --diff`
- `uv run --all-extras --dev pytest`
- `uv run --all-extras --dev mypy heracles`