### PR TITLE
Handle broad visitor callback annotations

### DIFF
--- a/heracles/ql/prelude.py
+++ b/heracles/ql/prelude.py
@@ -129,7 +129,11 @@ class _VisitorFuncWrapper(TimeseriesVisitor):
 
         sig = inspect.signature(func, eval_str=True)
         (param,) = sig.parameters.values()
-        self.accepted_type: type | None = param.annotation
+        self.accepted_type: type | None = (
+            None
+            if param.annotation is inspect.Parameter.empty or param.annotation is Any
+            else param.annotation
+        )
 
     def visit_node(self, v: Any) -> VisitorAction | None:
         if not self.accepted_type or isinstance(v, self.accepted_type):

--- a/test/stdlib/acceptance_test.py
+++ b/test/stdlib/acceptance_test.py
@@ -223,3 +223,20 @@ def test_all_binops_implemented(
 )
 def test_expressions(expr: ql.Timeseries, result: str) -> None:
     assert ql.format(expr.render()) == result
+
+
+def test_broad_visitor_functions_visit_all_nodes() -> None:
+    expr = ql.SelectedInstantVector(name="left") + 1
+
+    seen_unannotated: list[str] = []
+    expr.accept_visitor(lambda node: seen_unannotated.append(type(node).__name__))
+
+    seen_any: list[str] = []
+
+    def visit_any(node: Any) -> None:
+        seen_any.append(type(node).__name__)
+
+    expr.accept_visitor(visit_any)
+
+    assert seen_unannotated == ["BinaryOp", "SelectedInstantVector", "ScalarLiteral"]
+    assert seen_any == seen_unannotated


### PR DESCRIPTION
Fixes #18.

`_VisitorFuncWrapper` uses the first callback parameter annotation as an optional runtime filter. Concrete node annotations work, but callbacks with no annotation silently skip every node because `inspect.Parameter.empty` is treated as a filter value. Callbacks annotated as `Any` raise `TypeError` because `typing.Any` cannot be used with `isinstance()`.

This normalizes both cases to the existing visit-all path while leaving concrete typed callbacks unchanged. The regression covers an unannotated callback and an `Any` callback against the same expression tree.

Validation:
- `git diff --check`
- `.venv/bin/python -m pytest test/stdlib/acceptance_test.py::test_broad_visitor_functions_visit_all_nodes`
- `uv format --diff`
- `uv run --all-extras --dev pytest`
- `uv run --all-extras --dev mypy heracles`